### PR TITLE
feat: Add hexadecimal floating point number literal support

### DIFF
--- a/src/Cacco/Syntax/Parser/Numeric.hs
+++ b/src/Cacco/Syntax/Parser/Numeric.hs
@@ -14,6 +14,7 @@ import Data.Functor (
 import Data.List (foldl')
 import Data.Scientific (
     Scientific,
+    fromFloatDigits,
     scientific,
  )
 import Text.Megaparsec (
@@ -188,9 +189,9 @@ hexExponent e' = do
 
 -- Convert hexadecimal float to Scientific
 hexFloatToScientific :: Integer -> Double -> Int -> Scientific
-hexFloatToScientific mantissa fraction hexExponent =
-    let value = (fromInteger mantissa + fraction) * (2 ^^ hexExponent)
-    in scientific (round (value * 10^15)) (-15)  -- Approximate precision
+hexFloatToScientific mantissa fraction hexExp =
+    let value = (fromInteger mantissa + fraction) * (2 ^^ hexExp)
+    in fromFloatDigits value
 {-# INLINEABLE hexFloatToScientific #-}
 
 -- Hexadecimal literal (integer + floating point)

--- a/src/Cacco/Syntax/Parser/Numeric.hs
+++ b/src/Cacco/Syntax/Parser/Numeric.hs
@@ -162,11 +162,67 @@ decimalLiteral = do
     {-# INLINE suffixI #-}
 {-# INLINEABLE decimalLiteral #-}
 
+-- Parse hexadecimal decimal point
+hexFloatPoint :: Integer -> Parser (Integer, Double)
+hexFloatPoint c' = do
+    void $ char '.'
+    ds <- withDigitSep hexDigitChar
+    let (c, f) = foldl' acc (c', 0.0) (zip ds [1..])
+    return (c, f)
+  where
+    acc :: (Integer, Double) -> (Char, Int) -> (Integer, Double)
+    acc (a, f) (c, i) =
+        let f' = f + fromIntegral (digitToInt c) / (16 ^ i)
+        in (a, f')
+    {-# INLINE acc #-}
+{-# INLINEABLE hexFloatPoint #-}
+
+-- Parse hexadecimal exponent part
+hexExponent :: Int -> Parser Int
+hexExponent e' = do
+    void $ char 'p'
+    (_, f) <- signed
+    e <- decimal
+    return $ fromInteger (f e) + e'
+{-# INLINEABLE hexExponent #-}
+
+-- Convert hexadecimal float to Scientific
+hexFloatToScientific :: Integer -> Double -> Int -> Scientific
+hexFloatToScientific mantissa fraction hexExponent =
+    let value = (fromInteger mantissa + fraction) * (2 ^^ hexExponent)
+    in scientific (round (value * 10^15)) (-15)  -- Approximate precision
+{-# INLINEABLE hexFloatToScientific #-}
+
+-- Hexadecimal literal (integer + floating point)
 hexLiteral :: Parser Literal
 hexLiteral = do
     n <- hexadecimal
-    w <- option (Natural . fromInteger) $ char '_' >> unsignedInt <|> signedInt
-    return $ w n
+    -- Process as float if decimal point or exponent is present
+    option (defaultWrapper n) $ trail n
+  where
+    defaultWrapper = Natural . fromInteger
+
+    trail n = hexFloatPoint' n <|> hexExpo n <|> (($ n) <$> suffixI')
+    {-# INLINE trail #-}
+
+    hexFloatPoint' n = do
+        (c, f) <- hexFloatPoint n
+        e <- option 0 $ hexExponent 0
+        w <- option Flonum suffixF
+        return . w $ hexFloatToScientific c f e
+    {-# INLINEABLE hexFloatPoint' #-}
+
+    hexExpo n = do
+        e <- hexExponent 0
+        w <- option Flonum suffixF
+        return . w $ hexFloatToScientific n 0 e
+    {-# INLINE hexExpo #-}
+
+    suffixF = char '_' >> float
+    {-# INLINE suffixF #-}
+
+    suffixI' = char '_' >> unsignedInt <|> signedInt <|> float'
+    {-# INLINE suffixI' #-}
 {-# INLINEABLE hexLiteral #-}
 
 numeric :: Parser Literal

--- a/test/Cacco/Parser/NumericSpec.hs
+++ b/test/Cacco/Parser/NumericSpec.hs
@@ -73,6 +73,28 @@ spec_parse_strict_type_suffix = do
 
 --
 --
+spec_hex_float :: Spec
+spec_hex_float = do
+    let testParse = parse numeric "<test>"
+
+    it "0x1.0p1" $ testParse "0x1.0p1" `shouldBe` Right (Flonum 2.0)
+    --
+    it "0x1p1" $ testParse "0x1p1" `shouldBe` Right (Flonum 2.0)
+    --
+    it "0x1.0" $ testParse "0x1.0" `shouldBe` Right (Flonum 1.0)
+    --
+    it "0x0.1p4" $ testParse "0x0.1p4" `shouldBe` Right (Flonum 1.0)
+    --
+    it "0x1.0p-1" $ testParse "0x1.0p-1" `shouldBe` Right (Flonum 0.5)
+    --
+    it "0x10p-4" $ testParse "0x10p-4" `shouldBe` Right (Flonum 1.0)
+    --
+    it "0x1.0_f32" $ testParse "0x1.0_f32" `shouldBe` Right (Float32 1.0)
+    --
+    it "0x1p1_f64" $ testParse "0x1p1_f64" `shouldBe` Right (Float64 2.0)
+
+--
+--
 prop_parse_any_uint8 :: Word8 -> Bool
 prop_parse_any_uint8 x =
     let expr = Text.pack $ show x <> "_u8"

--- a/test/Cacco/ParserSpec.hs
+++ b/test/Cacco/ParserSpec.hs
@@ -63,6 +63,16 @@ spec_parseAst = do
             `shouldBe` Right
                 (App (Sym "var") [Sym "x", Lit $ Flonum 10.0])
     --
+    it "can parse \"0x1.0p1\"" $
+        testParse "0x1.0p1"
+            `shouldBe` Right
+                (Lit $ Flonum 2.0)
+    --
+    it "can parse \"0x1p1\"" $
+        testParse "0x1p1"
+            `shouldBe` Right
+                (Lit $ Flonum 2.0)
+    --
     it "can parse \"(set! x 0)\"" $
         testParse "(set! x 0)"
             `shouldBe` Right


### PR DESCRIPTION
Implement hexadecimal float literal parsing with comprehensive test cases.

- Support formats: 0x[integer].[fraction]p[exponent]  
- Examples: 0x1.0p1, 0x1.0, 0x0.1p4, 0x1.0p-1
- Add type suffixes support (_f16, _f32, _f64)
- Add comprehensive test cases
- All comments in English

Closes #3